### PR TITLE
RFC 016 - Slack channel names

### DIFF
--- a/rfc-016-slack-channel-names.md
+++ b/rfc-016-slack-channel-names.md
@@ -18,4 +18,4 @@ There is no standard naming convention for Slack channel names and as we grow th
 - You MUST prefix engineering topics with `#eng-`. For example, `#eng-k8s`, `#eng-react`, `#eng-tdd`.
 - You MUST prefix team channels with `#team-`. For example `#team-dmc`, `#team-sales`, `#team-people`, `#team-homes`, `#team-sre`.
 - You MUST prefix project channel with `#proj-`. For example `#proj-dmc-watg`, `#proj-homes-hif`, `#proj-productionisation`.
-- You MUST prefix collaboration channels with `#collab-`. For example `#collab-dmc`, `#collab-khc`.
+- You MUST suffix collaboration channels with `-collab`. For example `#team-dmc-collab`, `#team-khc-collab`, `#eng-k8s-collab`, `#animals-collab`.

--- a/rfc-016-slack-channel-names.md
+++ b/rfc-016-slack-channel-names.md
@@ -6,7 +6,7 @@ Guidelines for slack channel naming conventions building on [Slack's own guideli
 
 ## Problem
 
-There is no standard naming convention for Slack channel names and as we grow they become harder to discover. It's difficult to understand whether a channel is for discussion on topics or with teams. For example some SRE questions go into #live-services, some into #help, #engineering and even into #announcements.
+As we grow, it's harder to discover what sorts of things we're talking about. I'd like to know which teams we have, and what sorts of tech topics we're interested in, but I don't want to have to maintain a spreadsheet when our chat rooms already reflect this.
 
 ## Proposal
 

--- a/rfc-016-slack-channel-names.md
+++ b/rfc-016-slack-channel-names.md
@@ -16,6 +16,6 @@ There is no standard naming convention for Slack channel names and as we grow th
 - You MAY create collaboration channels and invite customers to them if you want to use Slack as a communication tool.
 
 - You MUST prefix engineering topics with `#eng-`. For example, `#eng-k8s`, `#eng-react`, `#eng-tdd`.
-- You MUST prefix team channels with `#team-`. For example `#team-dmc`, `#team-sales`, `#team-people`, `#team-homes`, `#team-sre`.
+- You MUST prefix team channels with `#team-`. For example `#team-dmc`, `#team-sales`, `#team-people`, `#team-homes`, `#team-live-services`.
 - You MUST prefix project channel with `#proj-`. For example `#proj-dmc-watg`, `#proj-homes-hif`, `#proj-productionisation`.
 - You MUST suffix collaboration channels with `-collab`. For example `#team-dmc-collab`, `#team-khc-collab`, `#eng-k8s-collab`, `#animals-collab`.

--- a/rfc-016-slack-channel-names.md
+++ b/rfc-016-slack-channel-names.md
@@ -1,0 +1,21 @@
+# Slack channel names
+
+## Summary
+
+Guidelines for slack channel naming conventions building on [Slack's own guidelines](https://get.slack.help/hc/en-us/articles/217626408-Create-guidelines-for-channel-names).
+
+## Problem
+
+There is no standard naming convention for Slack channel names and as we grow they become harder to discover. It's difficult to understand whether a channel is for discussion on topics or with teams. For example some SRE questions go into #live-services, some into #help, #engineering and even into #announcements.
+
+## Proposal
+
+- You SHOULD create discussion channels for particular engineering topics such as Kubernetes, React, etc.
+- You SHOULD create team channels for all teams within the business whether delivery teams, sales, etc.
+- You SHOULD create project channels for particular team projects that have a focussed goal, an example would be Homes HIF is a project of the Homes team.
+- You MAY create collaboration channels and invite customers to them if you want to use Slack as a communication tool.
+
+- You MUST prefix engineering topics with `#eng-`. For example, `#eng-k8s`, `#eng-react`, `#eng-tdd`.
+- You MUST prefix team channels with `#team-`. For example `#team-dmc`, `#team-sales`, `#team-people`, `#team-homes`, `#team-sre`.
+- You MUST prefix project channel with `#proj-`. For example `#proj-dmc-watg`, `#proj-homes-hif`, `#proj-productionisation`.
+- You MUST prefix collaboration channels with `#collab-`. For example `#collab-dmc`, `#collab-khc`.


### PR DESCRIPTION
Guidelines for slack channel naming conventions.